### PR TITLE
added query method on models

### DIFF
--- a/app/Console/Commands/AdminCommand.php
+++ b/app/Console/Commands/AdminCommand.php
@@ -43,7 +43,7 @@ class AdminCommand extends Command
         $email = $this->ask('Email Address');
         $password = $this->secret('Password');
 
-        Admin::create([
+        Admin::query()->create([
             'email' => $email,
             'name' => $name,
             'password' => Hash::make($password),

--- a/app/Console/Commands/ConvertVideoForStreaming.php
+++ b/app/Console/Commands/ConvertVideoForStreaming.php
@@ -40,7 +40,7 @@ class ConvertVideoForStreaming extends Command
      */
     public function handle()
     {
-        $video = Video::find($this->argument('id'));
+        $video = Video::query()->find($this->argument('id'));
         $video->update([
             'status' => 'notready'
         ]);

--- a/app/Http/Controllers/Frontend/PageController.php
+++ b/app/Http/Controllers/Frontend/PageController.php
@@ -68,7 +68,7 @@ class PageController extends Controller
     public function channel($slug, Request $request)
     {
         return view('frontend.page.channel')->with([
-            'channel' => Channel::where('slug', $slug)->firstOrFail()
+            'channel' => Channel::query()->where('slug', $slug)->firstOrFail()
         ]);
     }
 }

--- a/app/Http/Livewire/Backend/Admin/Modal/CreateAdmin.php
+++ b/app/Http/Livewire/Backend/Admin/Modal/CreateAdmin.php
@@ -46,7 +46,7 @@ class CreateAdmin extends ModalComponent
             'password' => ['required', 'min:8', 'same:passwordConfirmation'],
         ]);
 
-        Admin::create([
+        Admin::query()->create([
             'email' => $validated['email'],
             'name' => $validated['name'],
             'password' => Hash::make($validated['password']),

--- a/app/Http/Livewire/Backend/Admin/Modal/EditAdmin.php
+++ b/app/Http/Livewire/Backend/Admin/Modal/EditAdmin.php
@@ -25,7 +25,7 @@ class EditAdmin extends ModalComponent
 
     public function mount()
     {
-        $this->model = Admin::find($this->admin_id);
+        $this->model = Admin::query()->find($this->admin_id);
         $this->name = $this->model->name;
         $this->email = $this->model->email;
     }

--- a/app/Http/Livewire/Backend/Admin/Modal/ViewAdmin.php
+++ b/app/Http/Livewire/Backend/Admin/Modal/ViewAdmin.php
@@ -10,6 +10,7 @@ class ViewAdmin extends ModalComponent
     public $admin_id;
 
     public $name;
+
     public $email;
 
     public static function closeModalOnClickAway(): bool
@@ -19,7 +20,7 @@ class ViewAdmin extends ModalComponent
 
     public function mount()
     {
-        $this->model = Admin::find($this->admin_id);
+        $this->model = Admin::query()->find($this->admin_id);
         $this->name = $this->model->name;
         $this->email = $this->model->email;
     }

--- a/app/Http/Livewire/Backend/Channel/Modal/BanChannel.php
+++ b/app/Http/Livewire/Backend/Channel/Modal/BanChannel.php
@@ -21,7 +21,7 @@ class BanChannel extends ModalComponent
 
     public function mount()
     {
-        $this->model = Channel::find($this->channel_id);
+        $this->model = Channel::query()->find($this->channel_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Backend/Channel/Modal/BanUser.php
+++ b/app/Http/Livewire/Backend/Channel/Modal/BanUser.php
@@ -21,7 +21,7 @@ class BanUser extends ModalComponent
 
     public function mount()
     {
-        $this->model = User::find($this->user_id);
+        $this->model = User::query()->find($this->user_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Backend/Channel/Modal/BanVideo.php
+++ b/app/Http/Livewire/Backend/Channel/Modal/BanVideo.php
@@ -21,7 +21,7 @@ class BanVideo extends ModalComponent
 
     public function mount()
     {
-        $this->model = Video::find($this->video_id);
+        $this->model = Video::query()->find($this->video_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Backend/Channel/Modal/UnBanChannel.php
+++ b/app/Http/Livewire/Backend/Channel/Modal/UnBanChannel.php
@@ -18,7 +18,7 @@ class UnBanChannel extends ModalComponent
 
     public function mount()
     {
-        $this->model = Channel::find($this->channel_id);
+        $this->model = Channel::query()->find($this->channel_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Backend/Channel/Modal/UnBanUser.php
+++ b/app/Http/Livewire/Backend/Channel/Modal/UnBanUser.php
@@ -17,7 +17,7 @@ class UnBanUser extends ModalComponent
 
     public function mount()
     {
-        $this->model = User::find($this->user_id);
+        $this->model = User::query()->find($this->user_id);
     }
 
     public function submit()

--- a/app/Http/Livewire/Backend/Channel/Modal/UnBanVideo.php
+++ b/app/Http/Livewire/Backend/Channel/Modal/UnBanVideo.php
@@ -17,7 +17,7 @@ class UnBanVideo extends ModalComponent
 
     public function mount()
     {
-        $this->model = Video::find($this->video_id);
+        $this->model = Video::query()->find($this->video_id);
     }
 
     public function submit()

--- a/app/Http/Livewire/Backend/Channel/Modal/ViewVideo.php
+++ b/app/Http/Livewire/Backend/Channel/Modal/ViewVideo.php
@@ -17,7 +17,7 @@ class ViewVideo extends ModalComponent
 
     public function mount()
     {
-        $this->video = Video::find($this->video_id);
+        $this->video = Video::query()->find($this->video_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Frontend/Channel/Modal/CreateStream.php
+++ b/app/Http/Livewire/Frontend/Channel/Modal/CreateStream.php
@@ -34,7 +34,7 @@ class CreateStream extends ModalComponent
         $streaming_url = "/live/{$stream_key}/index.m3u8";
         $media_id = Str::random(10);
 
-        $channel = Channel::find($this->channel_id);
+        $channel = Channel::query()->find($this->channel_id);
         $video = $channel->videos()->create([
             'name' => $this->name,
             'description' => $this->description,

--- a/app/Http/Livewire/Frontend/Channel/Modal/EditChannel.php
+++ b/app/Http/Livewire/Frontend/Channel/Modal/EditChannel.php
@@ -24,7 +24,7 @@ class EditChannel extends ModalComponent
 
     public function mount()
     {
-        $this->model = Channel::find($this->channel_id);
+        $this->model = Channel::query()->find($this->channel_id);
         $this->name = $this->model->name;
         $this->slug = $this->model->slug;
         $this->active = $this->model->active;

--- a/app/Http/Livewire/Frontend/Channel/Modal/EditContent.php
+++ b/app/Http/Livewire/Frontend/Channel/Modal/EditContent.php
@@ -21,7 +21,7 @@ class EditContent extends ModalComponent
 
     public function mount()
     {
-        $this->model = Video::find($this->video_id);
+        $this->model = Video::query()->find($this->video_id);
         $this->name = $this->model->name;
         $this->description = $this->model->description;
     }

--- a/app/Http/Livewire/Frontend/Channel/Modal/ViewContent.php
+++ b/app/Http/Livewire/Frontend/Channel/Modal/ViewContent.php
@@ -32,7 +32,7 @@ class ViewContent extends ModalComponent
 
     public function mount()
     {
-        $this->video = Video::find($this->video_id);
+        $this->video = Video::query()->find($this->video_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Frontend/Channel/Partial/Analytic.php
+++ b/app/Http/Livewire/Frontend/Channel/Partial/Analytic.php
@@ -20,7 +20,7 @@ class Analytic extends Component
 
     public function getData()
     {
-        $this->video = Video::find($this->video_id);
+        $this->video = Video::query()->find($this->video_id);
         $this->subscribed_user_views = views($this->video)->unique()->collection('subscribed')->count();
         $this->unsubscribed_user_views = views($this->video)->unique()->collection('unsubscribed')->count();
         $this->total_views = $this->subscribed_user_views + $this->unsubscribed_user_views;

--- a/app/Http/Livewire/Frontend/Channel/Partial/ChannelAnalytics.php
+++ b/app/Http/Livewire/Frontend/Channel/Partial/ChannelAnalytics.php
@@ -18,7 +18,7 @@ class ChannelAnalytics extends Component
 
     public function getData()
     {
-        $this->channel = Channel::find($this->channel_id);
+        $this->channel = Channel::query()->find($this->channel_id);
         $this->count = $this->channel->subscribers()->count();
     }
 

--- a/app/Http/Livewire/Frontend/Channel/Partial/Settings.php
+++ b/app/Http/Livewire/Frontend/Channel/Partial/Settings.php
@@ -13,7 +13,7 @@ class Settings extends Component
 
     public function mount()
     {
-        $this->video = Video::find($this->video_id);
+        $this->video = Video::query()->find($this->video_id);
         $this->settings['allow_comments'] = $this->video->settings()->get('allow_comments', true);
         $this->settings['allow_download'] = $this->video->settings()->get('allow_download', true);
     }

--- a/app/Http/Livewire/Frontend/Channel/Partial/Thumbnail.php
+++ b/app/Http/Livewire/Frontend/Channel/Partial/Thumbnail.php
@@ -20,7 +20,7 @@ class Thumbnail extends Component
 
     public function mount()
     {
-        $this->video = Video::find($this->video_id);
+        $this->video = Video::query()->find($this->video_id);
 //        $this->getThumbnailsList();
     }
 

--- a/app/Http/Livewire/Frontend/Channel/ViewChannel.php
+++ b/app/Http/Livewire/Frontend/Channel/ViewChannel.php
@@ -94,7 +94,7 @@ class ViewChannel extends Component
 
     public function mount()
     {
-        $this->channel = Channel::find($this->channel_id);
+        $this->channel = Channel::query()->find($this->channel_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Frontend/Components/ChannelOwnerButton.php
+++ b/app/Http/Livewire/Frontend/Components/ChannelOwnerButton.php
@@ -17,7 +17,7 @@ class ChannelOwnerButton extends Component
 
     public function getData()
     {
-        $this->channel = Channel::find($this->channel_id);
+        $this->channel = Channel::query()->find($this->channel_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Frontend/Components/ChannelProfile.php
+++ b/app/Http/Livewire/Frontend/Components/ChannelProfile.php
@@ -30,7 +30,7 @@ class ChannelProfile extends Component
 
     public function getData()
     {
-        $this->channel = Channel::find($this->channel_id);
+        $this->channel = Channel::query()->find($this->channel_id);
         $this->name = $this->channel->name;
         $this->picture = Storage::disk($this->channel->disk)->url($this->channel->profile_picture);
         $this->count = $this->channel->subscribers()->count();

--- a/app/Http/Livewire/Frontend/Components/Comment.php
+++ b/app/Http/Livewire/Frontend/Components/Comment.php
@@ -43,7 +43,7 @@ class Comment extends Component
 
     public function getData()
     {
-        $this->video = Video::find($this->video_id);
+        $this->video = Video::query()->find($this->video_id);
     }
 
     public function submit()

--- a/app/Http/Livewire/Frontend/Components/LikeDislikeButton.php
+++ b/app/Http/Livewire/Frontend/Components/LikeDislikeButton.php
@@ -28,7 +28,7 @@ class LikeDislikeButton extends Component
 
     public function getData()
     {
-        $this->video = Video::find($this->video_id);
+        $this->video = Video::query()->find($this->video_id);
     }
 
     public function likeVideo()

--- a/app/Http/Livewire/Frontend/Components/SubscribeButton.php
+++ b/app/Http/Livewire/Frontend/Components/SubscribeButton.php
@@ -26,7 +26,7 @@ class SubscribeButton extends Component
 
     public function getData()
     {
-        $this->channel = Channel::find($this->channel_id);
+        $this->channel = Channel::query()->find($this->channel_id);
         $this->subscribe = auth()->check() ? auth()->user()->hasSubscribed($this->channel) : false;
     }
 

--- a/app/Http/Livewire/Frontend/Video/ChannelVideo.php
+++ b/app/Http/Livewire/Frontend/Video/ChannelVideo.php
@@ -27,7 +27,7 @@ class ChannelVideo extends Component
 
     public function mount()
     {
-        $this->channel = Channel::find($this->channel_id);
+        $this->channel = Channel::query()->find($this->channel_id);
     }
 
     public function render()

--- a/app/Http/Livewire/Frontend/Video/Modal/DeleteComment.php
+++ b/app/Http/Livewire/Frontend/Video/Modal/DeleteComment.php
@@ -23,7 +23,7 @@ class DeleteComment extends ModalComponent
 
     public function submit()
     {
-        $comment = Comment::find($this->comment_id);
+        $comment = Comment::query()->find($this->comment_id);
         $comment->delete();
 
         broadcast(new DynamicChannel("{$comment->commentable->media_id}.video.comments"));

--- a/app/Http/Livewire/Frontend/Video/Modal/EditComment.php
+++ b/app/Http/Livewire/Frontend/Video/Modal/EditComment.php
@@ -20,7 +20,7 @@ class EditComment extends ModalComponent
 
     public function mount()
     {
-        $this->comment = Comment::find($this->comment_id);
+        $this->comment = Comment::query()->find($this->comment_id);
         $this->message = $this->comment->comment;
     }
 

--- a/app/Http/Livewire/Frontend/Video/Modal/ReplyComment.php
+++ b/app/Http/Livewire/Frontend/Video/Modal/ReplyComment.php
@@ -25,7 +25,7 @@ class ReplyComment extends ModalComponent
 
     public function mount()
     {
-        $this->p_comment = Comment::find($this->comment_id);
+        $this->p_comment = Comment::query()->find($this->comment_id);
     }
 
     public function render()
@@ -39,7 +39,7 @@ class ReplyComment extends ModalComponent
             'message' => 'required|string'
         ]);
 
-        $commenter = $this->owner ? Channel::find($this->commenter['id']) : auth()->user();
+        $commenter = $this->owner ? Channel::query()->find($this->commenter['id']) : auth()->user();
 
         $rc = new Comment();
         $rc->parent()->associate($this->p_comment);

--- a/app/Listeners/TusEventListener.php
+++ b/app/Listeners/TusEventListener.php
@@ -25,7 +25,7 @@ class TusEventListener
             $duration = Str::contains($file['metadata']['type'],['video/x-matroska']) ? 0 : getVideoDurationInSeconds($path);
             $filesystem = config('site.converted_file_driver');
 
-            $channel = Channel::find($file['metadata']['channel']);
+            $channel = Channel::query()->find($file['metadata']['channel']);
             $channel->videos()->create([
                 'name' => 'untitled video',
                 'media_id' => Str::random(10),

--- a/search_replace.php
+++ b/search_replace.php
@@ -10,7 +10,7 @@ return [
             ],
             2 => [
                 "in_array" => [
-                    'where', 'count', 'find', 'findOrNew', 'findOrFail'
+                    'where', 'count', 'find', 'findOrNew', 'create', 'findOrFail'
                 ]
             ]
         ]


### PR DESCRIPTION
This add `query()->` on laravel models so that IDEs do not consider methods as absent.
This is automatically done by running the `php artisan refactor` command from the laravel-microscope.

The responsible pattern exists in the `search_replace.php` file.